### PR TITLE
Fix cannot determine folder_id in example

### DIFF
--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -1,9 +1,9 @@
 locals {
   zone   = "ru-central1-a"
-  folder = "xxxx"
+  folder = "folder_id"
 
-  network_name = "default"
-  subnet_name  = "default-ru-central1-a"
+  network_name = "network_name"
+  subnet_name  = "subnet_name"
 }
 
 data "yandex_vpc_network" "private" {

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -1,9 +1,9 @@
 locals {
   zone   = "ru-central1-a"
-  folder = "your_folder_id"
+  folder = "xxxx"
 
-  network_name = "private"
-  subnet_name  = "private-a"
+  network_name = "default"
+  subnet_name  = "default-ru-central1-a"
 }
 
 data "yandex_vpc_network" "private" {
@@ -12,7 +12,8 @@ data "yandex_vpc_network" "private" {
 }
 
 data "yandex_vpc_subnet" "private" {
-  name = local.subnet_name
+  folder_id = local.folder
+  name      = local.subnet_name
 }
 
 module "redis_simple" {
@@ -20,8 +21,8 @@ module "redis_simple" {
 
   name        = "cache"
   description = "Cache in-memory without sync to disk"
-
-  network_id = data.yandex_vpc_network.private.id
+  folder_id   = local.folder
+  network_id  = data.yandex_vpc_network.private.id
 
   persistence_mode = "OFF"
   password         = "secretpassword"

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -1,18 +1,18 @@
 locals {
   zone   = "ru-central1-a"
-  folder = "folder_id"
+  folder_id = "folder_id"
 
-  network_name = "network_name"
-  subnet_name  = "subnet_name"
+  network_name = "default"
+  subnet_name  = "default-ru-central1-a"
 }
 
 data "yandex_vpc_network" "private" {
-  folder_id = local.folder
+  folder_id = local.folder_id
   name      = local.network_name
 }
 
 data "yandex_vpc_subnet" "private" {
-  folder_id = local.folder
+  folder_id = local.folder_id
   name      = local.subnet_name
 }
 
@@ -21,7 +21,7 @@ module "redis_simple" {
 
   name        = "cache"
   description = "Cache in-memory without sync to disk"
-  folder_id   = local.folder
+  folder_id   = local.folder_id
   network_id  = data.yandex_vpc_network.private.id
 
   persistence_mode = "OFF"

--- a/examples/simple/outputs.tf
+++ b/examples/simple/outputs.tf
@@ -1,9 +1,10 @@
-output "status" {
-  description = "Status of the cluster"
-  value       = module.redis_simple.status
-}
-
 output "fqdn" {
   description = "The fully qualified domain name of the cluster"
   value       = module.redis_simple.fqdn
+}
+
+output "password" {
+  description = "The password of the host"
+  value       = module.redis_simple.password
+  sensitive   = true
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,6 +3,10 @@ output "fqdn" {
   value       = yandex_mdb_redis_cluster.this.host[*].fqdn
 }
 
+output "fqdn_redis" {
+  value = "c-${yandex_mdb_redis_cluster.this.id}.rw.mdb.yandexcloud.net"
+}
+
 output "password" {
   description = "The password of the host"
   value       = var.password

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,6 +3,11 @@ output "fqdn" {
   value       = yandex_mdb_redis_cluster.this.host[*].fqdn
 }
 
+output "password" {
+  description = "The password of the host"
+  value       = var.password
+}
+
 output "shard_name" {
   description = "The name of the shard to which the host belongs"
   value       = yandex_mdb_redis_cluster.this.host[*].shard_name

--- a/variables.tf
+++ b/variables.tf
@@ -156,7 +156,7 @@ variable "resource_preset_id" {
 variable "disk_size" {
   description = "Volume of the storage available to a host, in gigabytes"
   type        = number
-  default     = 8
+  default     = 20
 }
 
 variable "disk_type_id" {


### PR DESCRIPTION
Добавлен password в output
Увеличен disk_size до 20ГБ, так как с 8 ГБ redis создается медленно.
Fix:
```
│ Error: Error getting folder ID while creating Redis Cluster: cannot determine folder_id: please set 'folder_id' key in this resource or at provider level
│ 
│   with module.redis_simple.yandex_mdb_redis_cluster.this,
│   on ../../main.tf line 1, in resource "yandex_mdb_redis_cluster" "this":
│    1: resource "yandex_mdb_redis_cluster" "this" {
```

@terraform-yacloud-modules/maintainers Заревьюйте пожалуйста