### PR TITLE
feat: update Redis version to 7.2 in variables.tf

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -132,7 +132,7 @@ variable "databases" {
 variable "redis_version" {
   description = "Version of Redis"
   type        = string
-  default     = "6.2"
+  default     = "7.2"
 }
 
 variable "client_output_buffer_limit_normal" {


### PR DESCRIPTION
### Changes:
- Updated the `redis_version` variable default value from `6.2` to `7.2`.

Please review and provide feedback.