### PR TITLE
Исправление ошибки в динамическом блоке host

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -35,8 +35,8 @@ resource "yandex_mdb_redis_cluster" "this" {
   dynamic "host" {
     for_each = var.hosts
     content {
-      zone      = lookup(host.value, "zone", var.zone)
-      subnet_id = lookup(host.value, "subnet_id", var.subnet_id)
+      zone      = host.value
+      subnet_id = host.value
 
       shard_name = var.sharded ? lookup(host.value, "shard_name", "shard-${host.key}") : null
 

--- a/main.tf
+++ b/main.tf
@@ -32,19 +32,6 @@ resource "yandex_mdb_redis_cluster" "this" {
     disk_type_id       = var.disk_type_id
   }
 
-  lifecycle {
-    precondition {
-      condition = length([
-        for host in var.hosts : host.zone
-        if !contains(["ru-central1-a", "ru-central1-b", "ru-central1-c", "ru-central1-d"], host.zone)
-      ]) == 0
-      error_message = join(", ", [
-        for host in var.hosts : "Host ${host.key} has invalid zone '${host.zone}'"
-        if !contains(["ru-central1-a", "ru-central1-b", "ru-central1-c", "ru-central1-d"], host.zone)
-      ])
-    }
-  }
-
   dynamic "host" {
     for_each = var.hosts
     content {

--- a/main.tf
+++ b/main.tf
@@ -35,9 +35,13 @@ resource "yandex_mdb_redis_cluster" "this" {
   dynamic "host" {
     for_each = var.hosts
     content {
-      zone      = host.value
-      subnet_id = host.value
+      zone      = host.value.zone
+      subnet_id = host.value.subnet_id
 
+      precondition {
+        condition     = contains(["ru-central1-a", "ru-central1-b", "ru-central1-c", "ru-central1-d"], host.value.zone)
+        error_message = "Zone must be one of `ru-central1-a`, `ru-central1-b`, `ru-central1-c`, or `ru-central1-d`."
+      }
       shard_name = var.sharded ? lookup(host.value, "shard_name", "shard-${host.key}") : null
 
       replica_priority = var.sharded ? null : var.replica_priority

--- a/variables.tf
+++ b/variables.tf
@@ -170,22 +170,6 @@ variable "disk_type_id" {
   }
 }
 
-variable "zone" {
-  description = "The availability zone where the Redis host will be created. See https://cloud.yandex.com/en/docs/overview/concepts/geo-scope"
-  type        = string
-
-  validation {
-    condition     = contains(["ru-central1-a", "ru-central1-b", "ru-central1-c", "ru-central1-d"], var.zone)
-    error_message = "Zone must be one of `ru-central1-a`, `ru-central1-b`, `ru-central1-c` or `ru-central1-d` (with limitations)."
-  }
-}
-
-variable "subnet_id" {
-  description = "The ID of the subnet, to which the host belongs. The subnet must be a part of the network to which the cluster belongs"
-  type        = string
-  default     = null
-}
-
 variable "replica_priority" {
   description = "Replica priority of a current replica (usable for non-sharded only)"
   type        = any


### PR DESCRIPTION
В данном PR выполнены следующие изменения:

1. **Удаление переменных `zone` и `subnet_id`:**  
   Переменные `zone` и `subnet_id` были удалены из `variables.tf`, так как их значения теперь напрямую берутся из конфигурации хостов. Это упрощает конфигурацию и делает её более явной.

2. **Изменение логики в `main.tf`:**  
   В блоке `dynamic "host"` для ресурса `yandex_mdb_redis_cluster` изменена логика получения значений `zone` и `subnet_id`. Теперь они напрямую берутся из `host.value`, вместо использования функции `lookup` с fallback на переменные `zone` и `subnet_id`.

3. Проверено здесь https://github.com/patsevanton/redis-dump-go-vs-redis-rdb-cli/blob/main/main.tf#L22

**Дополнительная информация:**  
Если у вас есть вопросы или замечания, пожалуйста, дайте знать!