### PR TITLE
Fix redis_version

### DIFF
--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -38,8 +38,6 @@ module "redis_simple" {
     }
   }
 
-  zone = "ru-central1-a"
-
   type = "WEEKLY"
   hour = "03"
   day  = "MON"

--- a/variables.tf
+++ b/variables.tf
@@ -130,9 +130,13 @@ variable "databases" {
 }
 
 variable "redis_version" {
-  description = "Version of Redis"
+  description = "Version of the Redis server"
   type        = string
-  default     = "7.2"
+  default     = "7.2-valkey"
+  validation {
+    condition     = contains(["7.2-valkey", "8.0-valkey", "8.1-valkey"], var.redis_version)
+    error_message = "The Redis server version must be 7.2-valkey, 8.0-valkey, 8.1-valkey"
+  }
 }
 
 variable "client_output_buffer_limit_normal" {


### PR DESCRIPTION
Fix error:

│ Error: Error while requesting API to create Redis Cluster: client-request-id = 89146dab-6ec0-48bf-82ca-ea4d90f964ce client-trace-id = 007f9ea2-27d2-4c86-9cf5-7bfd16397e71 rpc error: code = InvalidArgument desc = version "7.2" is deprecated, allowed versions are: 7.2-valkey, 8.0-valkey, 8.1-valkey
│ 
│   with module.redis_simple.yandex_mdb_redis_cluster.this,
│   on ../../main.tf line 1, in resource "yandex_mdb_redis_cluster" "this":
│    1: resource "yandex_mdb_redis_cluster" "this" {

