### PR TITLE
fix(redis-user): add optional user creation to avoid provider error, add user password validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,8 +164,8 @@ No modules.
 | <a name="input_turn_before_switchover"></a> [turn\_before\_switchover](#input\_turn\_before\_switchover) | Allows to turn before switchover in RDSync | `bool` | `false` | no |
 | <a name="input_type"></a> [type](#input\_type) | Type of maintenance window. Can be either ANYTIME or WEEKLY. A day and hour of window need to be specified with weekly window | `string` | `"ANYTIME"` | no |
 | <a name="input_use_luajit"></a> [use\_luajit](#input\_use\_luajit) | Enable LuaJIT engine | `bool` | `false` | no |
-| <a name="input_user_name"></a> [user\_name](#input\_user\_name) | Name of the Redis user | `string` | `null` | no |
-| <a name="input_user_password"></a> [user\_password](#input\_user\_password) | Password for the Redis user | `string` | `null` | no |
+| <a name="input_user_name"></a> [user\_name](#input\_user\_name) | Name of the Redis user. Required together with user_password when provisioning | `string` | `null` | no |
+| <a name="input_user_password"></a> [user\_password](#input\_user\_password) | Password for the Redis user. Required together with user_name when provisioning | `string` | `null` | no |
 | <a name="input_user_permissions_categories"></a> [user\_permissions\_categories](#input\_user\_permissions\_categories) | Redis command categories allowed for the user. Leave empty unless needed | `string` | `""` | no |
 | <a name="input_user_permissions_commands"></a> [user\_permissions\_commands](#input\_user\_permissions\_commands) | Redis commands allowed for the user (e.g. '+get +set') | `string` | `"+get +set"` | no |
 | <a name="input_user_permissions_patterns"></a> [user\_permissions\_patterns](#input\_user\_permissions\_patterns) | Key patterns allowed for the user. Must start with ~, %R~, %W~ or %RW~ (e.g. '~*' for all keys) | `string` | `"~*"` | no |

--- a/main.tf
+++ b/main.tf
@@ -108,6 +108,11 @@ resource "yandex_mdb_redis_cluster" "this" {
   }
 }
 
+moved {
+  from = yandex_mdb_redis_user.this
+  to   = yandex_mdb_redis_user.this[0]
+}
+
 resource "yandex_mdb_redis_user" "this" {
   count = var.user_name != null && var.user_password != null ? 1 : 0
 

--- a/main.tf
+++ b/main.tf
@@ -109,6 +109,8 @@ resource "yandex_mdb_redis_cluster" "this" {
 }
 
 resource "yandex_mdb_redis_user" "this" {
+  count = var.user_name != null && var.user_password != null ? 1 : 0
+
   cluster_id = yandex_mdb_redis_cluster.this.id
   name       = var.user_name
   passwords  = [var.user_password]

--- a/variables.tf
+++ b/variables.tf
@@ -410,6 +410,11 @@ variable "user_password" {
   type        = string
   sensitive   = true
   default     = null
+
+  validation {
+    condition     = var.user_password == null || length(var.user_password) >= 8
+    error_message = "Password must be at least 8 characters long when set."
+  }
 }
 
 variable "user_permissions_commands" {


### PR DESCRIPTION
При попытке вызова ресурса `yandex_mdb_redis_user` без объявления переменных `user_name` и/или `user_password`  plan/apply падал с ошибкой от провайдера:

```
  │ Error: Missing Configuration for Required Attribute
  │ 
  │   with yandex_mdb_redis_user.this,
  │   on main.tf line 113, in resource "yandex_mdb_redis_user" "this":
  │  113:   name       = var.user_name
  │ 
  │ Must set a configuration value for the name attribute as the provider has
  │ marked it as required.
  │ 
  │ Refer to the provider documentation or contact the provider developers for
  │ additional information about configurable attributes that are required.
```
Общаясь к [документации провайдера](https://yandex.cloud/ru/docs/terraform/resources/mdb_redis_user) для создания ресурса необходимо задать сразу и `user_name` и `user_password`.
Реализовал проверку наличия/отсутствия переменных, указал необходимость объявления сразу двух переменных при создании `yandex_mdb_redis_user` и добавил проверку длины `user_password`.
Внесены изменения в:
- [main.tf](https://github.com/terraform-yacloud-modules/terraform-yandex-redis/compare/main...akulichmark:terraform-yandex-redis:main?expand=1#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbb)
- [variables.tf](https://github.com/terraform-yacloud-modules/terraform-yandex-redis/compare/main...akulichmark:terraform-yandex-redis:main?expand=1#diff-05b5a57c136b6ff596500bcbfdcff145ef6cddea2a0e86d184d9daa9a65a288e)
- [README.md](https://github.com/terraform-yacloud-modules/terraform-yandex-redis/compare/main...akulichmark:terraform-yandex-redis:main?expand=1#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5)
EDIT: Добавил moved block для обратной совместимости