### PR TITLE
feat: migrate to yandex_mdb_redis_cluster_v2 and add modules support

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,17 +90,17 @@ maintainers to test your changes and to keep the examples up to date for users. 
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0 |
-| <a name="requirement_yandex"></a> [yandex](#requirement\_yandex) | >= 0.47.0 |
+| <a name="requirement_yandex"></a> [yandex](#requirement\_yandex) | >= 0.183.0 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.0 |
-| <a name="provider_yandex"></a> [yandex](#provider\_yandex) | >= 0.47.0 |
+| <a name="provider_yandex"></a> [yandex](#provider\_yandex) | >= 0.183.0 |
 
 ## Modules
 
@@ -109,15 +109,15 @@ No modules.
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [random_password.user](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
-| [yandex_mdb_redis_cluster.this](https://registry.terraform.io/providers/yandex-cloud/yandex/latest/docs/resources/mdb_redis_cluster) | resource |
+| [yandex_mdb_redis_cluster_v2.this](https://registry.terraform.io/providers/yandex-cloud/yandex/latest/docs/resources/mdb_redis_cluster_v2) | resource |
 | [yandex_mdb_redis_user.this](https://registry.terraform.io/providers/yandex-cloud/yandex/latest/docs/resources/mdb_redis_user) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_access"></a> [access](#input\_access) | Access policy for DataLens and WebSQL | <pre>object({<br/>    data_lens = optional(bool)<br/>    web_sql   = optional(bool)<br/>  })</pre> | `null` | no |
 | <a name="input_allow_data_loss"></a> [allow\_data\_loss](#input\_allow\_data\_loss) | Allows some data to be lost for faster switchover/restart | `bool` | `false` | no |
 | <a name="input_announce_hostnames"></a> [announce\_hostnames](#input\_announce\_hostnames) | Enable FQDN instead of IP addresses in CLUSTER SLOTS command | `bool` | `false` | no |
@@ -148,6 +148,7 @@ No modules.
 | <a name="input_lua_time_limit"></a> [lua\_time\_limit](#input\_lua\_time\_limit) | Maximum time in milliseconds for Lua scripts | `number` | `5000` | no |
 | <a name="input_maxmemory_percent"></a> [maxmemory\_percent](#input\_maxmemory\_percent) | Redis maxmemory usage in percent | `number` | `75` | no |
 | <a name="input_maxmemory_policy"></a> [maxmemory\_policy](#input\_maxmemory\_policy) | Redis key eviction policy for a dataset that reaches maximum memory. See https://docs.redis.com/latest/rs/databases/memory-performance/eviction-policy/ | `string` | `"NOEVICTION"` | no |
+| <a name="input_modules"></a> [modules](#input\_modules) | Valkey modules configuration | <pre>object({<br/>    valkey_search = optional(object({<br/>      enabled        = optional(bool)<br/>      reader_threads = optional(number)<br/>      writer_threads = optional(number)<br/>    }))<br/>    valkey_json = optional(object({<br/>      enabled = optional(bool)<br/>    }))<br/>    valkey_bloom = optional(object({<br/>      enabled = optional(bool)<br/>    }))<br/>  })</pre> | `null` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name of the Redis cluster | `string` | n/a | yes |
 | <a name="input_network_id"></a> [network\_id](#input\_network\_id) | ID of the network, to which the Redis cluster belongs | `string` | n/a | yes |
 | <a name="input_notify_keyspace_events"></a> [notify\_keyspace\_events](#input\_notify\_keyspace\_events) | Select the events that Redis will notify among a set of classes | `string` | `""` | no |
@@ -172,12 +173,13 @@ No modules.
 | <a name="input_user_permissions_categories"></a> [user\_permissions\_categories](#input\_user\_permissions\_categories) | Redis command categories allowed for the user. Leave empty unless needed | `string` | `""` | no |
 | <a name="input_user_permissions_commands"></a> [user\_permissions\_commands](#input\_user\_permissions\_commands) | Redis commands allowed for the user (e.g. '+get +set') | `string` | `"+get +set"` | no |
 | <a name="input_user_permissions_patterns"></a> [user\_permissions\_patterns](#input\_user\_permissions\_patterns) | Key patterns allowed for the user. Must start with ~, %R~, %W~ or %RW~ (e.g. '~*' for all keys) | `string` | `"~*"` | no |
+| <a name="input_zone"></a> [zone](#input\_zone) | The availability zone where Redis hosts will be created when a host-specific zone is not provided. See https://cloud.yandex.com/en/docs/overview/concepts/geo-scope | `string` | `"ru-central1-a"` | no |
 | <a name="input_zset_max_listpack_entries"></a> [zset\_max\_listpack\_entries](#input\_zset\_max\_listpack\_entries) | Controls max number of entries in zset before conversion | `number` | `128` | no |
 
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_config"></a> [config](#output\_config) | Configuration of the Redis cluster |
 | <a name="output_created_at"></a> [created\_at](#output\_created\_at) | Creation timestamp of the cluster |
 | <a name="output_deletion_protection"></a> [deletion\_protection](#output\_deletion\_protection) | Inhibits deletion of the cluster |
@@ -185,11 +187,12 @@ No modules.
 | <a name="output_environment"></a> [environment](#output\_environment) | Deployment environment of the Redis cluster |
 | <a name="output_folder_id"></a> [folder\_id](#output\_folder\_id) | ID of the folder that the resource belongs to |
 | <a name="output_fqdn"></a> [fqdn](#output\_fqdn) | FQDN for the Redis cluster |
-| <a name="output_health"></a> [health](#output\_health) | Aggregated health of the cluster |
+| <a name="output_health"></a> [health](#output\_health) | Aggregated health of the cluster. Not exposed by yandex\_mdb\_redis\_cluster\_v2. |
 | <a name="output_hosts"></a> [hosts](#output\_hosts) | A list of hosts in the Redis cluster |
 | <a name="output_id"></a> [id](#output\_id) | ID of the Redis cluster |
 | <a name="output_labels"></a> [labels](#output\_labels) | A set of key/value label pairs to assign to the Redis cluster |
 | <a name="output_maintenance_window"></a> [maintenance\_window](#output\_maintenance\_window) | Maintenance policy of the Redis cluster |
+| <a name="output_modules"></a> [modules](#output\_modules) | Valkey modules configuration |
 | <a name="output_name"></a> [name](#output\_name) | Name of the Redis cluster |
 | <a name="output_network_id"></a> [network\_id](#output\_network\_id) | ID of the network to which the Redis cluster belongs |
 | <a name="output_persistence_mode"></a> [persistence\_mode](#output\_persistence\_mode) | Persistence mode of the Redis cluster |
@@ -204,95 +207,3 @@ No modules.
 
 Apache-2.0 Licensed.
 See [LICENSE](https://github.com/terraform-yacloud-modules/terraform-yandex-module-template/blob/main/LICENSE).
-
-<!-- BEGIN_TF_DOCS -->
-## Requirements
-
-| Name | Version |
-|------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
-| <a name="requirement_yandex"></a> [yandex](#requirement\_yandex) | >= 0.47.0 |
-
-## Providers
-
-| Name | Version |
-|------|---------|
-| <a name="provider_yandex"></a> [yandex](#provider\_yandex) | 0.164.0 |
-
-## Modules
-
-No modules.
-
-## Resources
-
-| Name | Type |
-|------|------|
-| [yandex_mdb_redis_cluster.this](https://registry.terraform.io/providers/yandex-cloud/yandex/latest/docs/resources/mdb_redis_cluster) | resource |
-
-## Inputs
-
-| Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
-| <a name="input_access"></a> [access](#input\_access) | Access policy for DataLens and WebSQL | <pre>object({<br/>    data_lens = optional(bool)<br/>    web_sql   = optional(bool)<br/>  })</pre> | `null` | no |
-| <a name="input_announce_hostnames"></a> [announce\_hostnames](#input\_announce\_hostnames) | Enable FQDN instead of IP addresses in CLUSTER SLOTS command | `bool` | `false` | no |
-| <a name="input_assign_public_ip"></a> [assign\_public\_ip](#input\_assign\_public\_ip) | Sets whether the host should get a public IP address or not | `bool` | `false` | no |
-| <a name="input_auth_sentinel"></a> [auth\_sentinel](#input\_auth\_sentinel) | Allow ACL based authentication in Redis Sentinel | `bool` | `false` | no |
-| <a name="input_backup_window_start"></a> [backup\_window\_start](#input\_backup\_window\_start) | Time to start the daily backup, in the UTC timezone. The structure is documented below | <pre>object({<br/>    hours   = number<br/>    minutes = optional(number)<br/>  })</pre> | `null` | no |
-| <a name="input_client_output_buffer_limit_normal"></a> [client\_output\_buffer\_limit\_normal](#input\_client\_output\_buffer\_limit\_normal) | Normal clients output buffer limits (bytes) | `string` | `"1073741824 536870912 60"` | no |
-| <a name="input_client_output_buffer_limit_pubsub"></a> [client\_output\_buffer\_limit\_pubsub](#input\_client\_output\_buffer\_limit\_pubsub) | Pubsub clients output buffer limits (bytes) | `string` | `"1073741824 536870912 60"` | no |
-| <a name="input_databases"></a> [databases](#input\_databases) | Number of databases (changing requires redis-server restart) | `number` | `16` | no |
-| <a name="input_day"></a> [day](#input\_day) | Day of week for maintenance window if window type is weekly | `string` | `"MON"` | no |
-| <a name="input_deletion_protection"></a> [deletion\_protection](#input\_deletion\_protection) | Inhibits deletion of the cluster | `bool` | `false` | no |
-| <a name="input_description"></a> [description](#input\_description) | Description of the Redis cluster | `string` | `"Redis cluster"` | no |
-| <a name="input_disk_encryption_key_id"></a> [disk\_encryption\_key\_id](#input\_disk\_encryption\_key\_id) | ID of the KMS key used for disk encryption | `string` | `null` | no |
-| <a name="input_disk_size"></a> [disk\_size](#input\_disk\_size) | Volume of the storage available to a host, in gigabytes | `number` | `20` | no |
-| <a name="input_disk_size_autoscaling"></a> [disk\_size\_autoscaling](#input\_disk\_size\_autoscaling) | Disk size autoscaling configuration | <pre>object({<br/>    disk_size_limit           = number<br/>    planned_usage_threshold   = optional(number)<br/>    emergency_usage_threshold = optional(number)<br/>  })</pre> | `null` | no |
-| <a name="input_disk_type_id"></a> [disk\_type\_id](#input\_disk\_type\_id) | Type of the storage of Redis hosts - environment default is used if missing | `string` | `"network-ssd"` | no |
-| <a name="input_environment"></a> [environment](#input\_environment) | Deployment environment of the Redis cluster. Can be either PRESTABLE or PRODUCTION | `string` | `"PRODUCTION"` | no |
-| <a name="input_folder_id"></a> [folder\_id](#input\_folder\_id) | The ID of the folder that the resource belongs to. If it is not provided, the default provider folder is used | `string` | `null` | no |
-| <a name="input_hosts"></a> [hosts](#input\_hosts) | Redis hosts definition | `map(any)` | n/a | yes |
-| <a name="input_hour"></a> [hour](#input\_hour) | Hour of day in UTC time zone (1-24) for maintenance window if window type is weekly | `number` | `24` | no |
-| <a name="input_io_threads_allowed"></a> [io\_threads\_allowed](#input\_io\_threads\_allowed) | Enable IO threads for Redis (improves performance for concurrent connections) | `bool` | `false` | no |
-| <a name="input_labels"></a> [labels](#input\_labels) | A set of key/value label pairs to assign to the Redis cluster | `map(string)` | `{}` | no |
-| <a name="input_maxmemory_policy"></a> [maxmemory\_policy](#input\_maxmemory\_policy) | Redis key eviction policy for a dataset that reaches maximum memory. See https://docs.redis.com/latest/rs/databases/memory-performance/eviction-policy/ | `string` | `"NOEVICTION"` | no |
-| <a name="input_name"></a> [name](#input\_name) | Name of the Redis cluster | `string` | n/a | yes |
-| <a name="input_network_id"></a> [network\_id](#input\_network\_id) | ID of the network, to which the Redis cluster belongs | `string` | n/a | yes |
-| <a name="input_notify_keyspace_events"></a> [notify\_keyspace\_events](#input\_notify\_keyspace\_events) | Select the events that Redis will notify among a set of classes | `string` | `""` | no |
-| <a name="input_password"></a> [password](#input\_password) | Password for the Redis cluster | `string` | n/a | yes |
-| <a name="input_persistence_mode"></a> [persistence\_mode](#input\_persistence\_mode) | Persistence mode. Must be one of OFF or ON | `string` | `"ON"` | no |
-| <a name="input_redis_version"></a> [redis\_version](#input\_redis\_version) | Version of Redis | `string` | `"7.2"` | no |
-| <a name="input_replica_priority"></a> [replica\_priority](#input\_replica\_priority) | Replica priority of a current replica (usable for non-sharded only) | `any` | `null` | no |
-| <a name="input_resource_preset_id"></a> [resource\_preset\_id](#input\_resource\_preset\_id) | The ID of the preset for computational resources available to a host (CPU, memory etc.). See https://cloud.yandex.com/en/docs/managed-redis/concepts/instance-types | `string` | `"b3-c1-m4"` | no |
-| <a name="input_security_group_ids"></a> [security\_group\_ids](#input\_security\_group\_ids) | A set of ids of security groups assigned to hosts of the cluster | `list(string)` | `[]` | no |
-| <a name="input_sharded"></a> [sharded](#input\_sharded) | Redis Cluster mode enabled/disabled | `bool` | `false` | no |
-| <a name="input_slowlog_log_slower_than"></a> [slowlog\_log\_slower\_than](#input\_slowlog\_log\_slower\_than) | Log slow queries below this number in microseconds | `number` | `10000` | no |
-| <a name="input_slowlog_max_len"></a> [slowlog\_max\_len](#input\_slowlog\_max\_len) | Slow queries log length | `number` | `1000` | no |
-| <a name="input_timeout"></a> [timeout](#input\_timeout) | Close the connection after a client is idle for N seconds | `number` | `0` | no |
-| <a name="input_tls_enabled"></a> [tls\_enabled](#input\_tls\_enabled) | TLS support mode enabled/disabled | `bool` | `false` | no |
-| <a name="input_type"></a> [type](#input\_type) | Type of maintenance window. Can be either ANYTIME or WEEKLY. A day and hour of window need to be specified with weekly window | `string` | `"ANYTIME"` | no |
-| <a name="input_use_luajit"></a> [use\_luajit](#input\_use\_luajit) | Enable LuaJIT engine | `bool` | `false` | no |
-
-## Outputs
-
-| Name | Description |
-|------|-------------|
-| <a name="output_config"></a> [config](#output\_config) | Configuration of the Redis cluster |
-| <a name="output_created_at"></a> [created\_at](#output\_created\_at) | Creation timestamp of the cluster |
-| <a name="output_deletion_protection"></a> [deletion\_protection](#output\_deletion\_protection) | Inhibits deletion of the cluster |
-| <a name="output_description"></a> [description](#output\_description) | Description of the Redis cluster |
-| <a name="output_environment"></a> [environment](#output\_environment) | Deployment environment of the Redis cluster |
-| <a name="output_folder_id"></a> [folder\_id](#output\_folder\_id) | ID of the folder that the resource belongs to |
-| <a name="output_fqdn"></a> [fqdn](#output\_fqdn) | FQDN for the Redis cluster |
-| <a name="output_health"></a> [health](#output\_health) | Aggregated health of the cluster |
-| <a name="output_hosts"></a> [hosts](#output\_hosts) | A list of hosts in the Redis cluster |
-| <a name="output_id"></a> [id](#output\_id) | ID of the Redis cluster |
-| <a name="output_labels"></a> [labels](#output\_labels) | A set of key/value label pairs to assign to the Redis cluster |
-| <a name="output_maintenance_window"></a> [maintenance\_window](#output\_maintenance\_window) | Maintenance policy of the Redis cluster |
-| <a name="output_name"></a> [name](#output\_name) | Name of the Redis cluster |
-| <a name="output_network_id"></a> [network\_id](#output\_network\_id) | ID of the network to which the Redis cluster belongs |
-| <a name="output_persistence_mode"></a> [persistence\_mode](#output\_persistence\_mode) | Persistence mode of the Redis cluster |
-| <a name="output_resources"></a> [resources](#output\_resources) | Resources allocated to hosts of the Redis cluster |
-| <a name="output_security_group_ids"></a> [security\_group\_ids](#output\_security\_group\_ids) | A set of ids of security groups assigned to hosts of the cluster |
-| <a name="output_sharded"></a> [sharded](#output\_sharded) | Redis Cluster mode enabled/disabled |
-| <a name="output_tls_enabled"></a> [tls\_enabled](#output\_tls\_enabled) | TLS support mode enabled/disabled |
-<!-- END_TF_DOCS -->

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ No modules.
 | <a name="input_user_permissions_categories"></a> [user\_permissions\_categories](#input\_user\_permissions\_categories) | Redis command categories allowed for the user. Leave empty unless needed | `string` | `""` | no |
 | <a name="input_user_permissions_commands"></a> [user\_permissions\_commands](#input\_user\_permissions\_commands) | Redis commands allowed for the user (e.g. '+get +set') | `string` | `"+get +set"` | no |
 | <a name="input_user_permissions_patterns"></a> [user\_permissions\_patterns](#input\_user\_permissions\_patterns) | Key patterns allowed for the user. Must start with ~, %R~, %W~ or %RW~ (e.g. '~*' for all keys) | `string` | `"~*"` | no |
-| <a name="input_zone"></a> [zone](#input\_zone) | The availability zone where Redis hosts will be created when a host-specific zone is not provided. See https://cloud.yandex.com/en/docs/overview/concepts/geo-scope | `string` | `"ru-central1-a"` | no |
+| <a name="input_zone"></a> [zone](#input\_zone) | The availability zone where Redis hosts will be created when a host-specific zone is not provided.<br/>See https://cloud.yandex.com/en/docs/overview/concepts/geo-scope<br/>Example values: ru-central1-a, ru-central1-b, ru-central1-d, ru-central1-e, kz1-a. | `string` | n/a | yes |
 | <a name="input_zset_max_listpack_entries"></a> [zset\_max\_listpack\_entries](#input\_zset\_max\_listpack\_entries) | Controls max number of entries in zset before conversion | `number` | `128` | no |
 
 ## Outputs

--- a/examples/shared/README.md
+++ b/examples/shared/README.md
@@ -16,27 +16,27 @@ Note that this example may create resources which can cost money. Run `terraform
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
 | <a name="requirement_yandex"></a> [yandex](#requirement\_yandex) | >= 0.47.0 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_yandex"></a> [yandex](#provider\_yandex) | >= 0.47.0 |
 
 ## Modules
 
 | Name | Source | Version |
-|------|--------|---------|
+| ---- | ------ | ------- |
 | <a name="module_network"></a> [network](#module\_network) | git::https://github.com/terraform-yacloud-modules/terraform-yandex-vpc.git | v1.0.0 |
 | <a name="module_redis_sharded"></a> [redis\_sharded](#module\_redis\_sharded) | ../.. | n/a |
 
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [yandex_client_config.client](https://registry.terraform.io/providers/yandex-cloud/yandex/latest/docs/data-sources/client_config) | data source |
 
 ## Inputs
@@ -46,7 +46,7 @@ No inputs.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_config"></a> [config](#output\_config) | Configuration of the Redis cluster |
 | <a name="output_created_at"></a> [created\_at](#output\_created\_at) | Creation timestamp of the cluster |
 | <a name="output_deletion_protection"></a> [deletion\_protection](#output\_deletion\_protection) | Inhibits deletion of the cluster |

--- a/examples/shared/main.tf
+++ b/examples/shared/main.tf
@@ -22,6 +22,7 @@ module "redis_sharded" {
   source = "../.."
 
   name        = "sharded_cluster"
+  zone        = "ru-central1-a"
   description = "Sharded zonal cluster"
 
   network_id = module.network.vpc_id

--- a/examples/simple/README.md
+++ b/examples/simple/README.md
@@ -16,27 +16,27 @@ Note that this example may create resources which can cost money. Run `terraform
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
 | <a name="requirement_yandex"></a> [yandex](#requirement\_yandex) | >= 0.47.0 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_yandex"></a> [yandex](#provider\_yandex) | >= 0.47.0 |
 
 ## Modules
 
 | Name | Source | Version |
-|------|--------|---------|
+| ---- | ------ | ------- |
 | <a name="module_network"></a> [network](#module\_network) | git::https://github.com/terraform-yacloud-modules/terraform-yandex-vpc.git | v1.0.0 |
 | <a name="module_redis_simple"></a> [redis\_simple](#module\_redis\_simple) | ../../ | n/a |
 
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [yandex_client_config.client](https://registry.terraform.io/providers/yandex-cloud/yandex/latest/docs/data-sources/client_config) | data source |
 
 ## Inputs
@@ -46,7 +46,7 @@ No inputs.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_config"></a> [config](#output\_config) | Configuration of the Redis cluster |
 | <a name="output_created_at"></a> [created\_at](#output\_created\_at) | Creation timestamp of the cluster |
 | <a name="output_deletion_protection"></a> [deletion\_protection](#output\_deletion\_protection) | Inhibits deletion of the cluster |

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -22,6 +22,7 @@ module "redis_simple" {
   source = "../../"
 
   name        = "cache"
+  zone        = "ru-central1-a"
   description = "Cache in-memory without sync to disk"
   folder_id   = data.yandex_client_config.client.folder_id
   network_id  = module.network.vpc_id

--- a/main.tf
+++ b/main.tf
@@ -1,4 +1,4 @@
-resource "yandex_mdb_redis_cluster" "this" {
+resource "yandex_mdb_redis_cluster_v2" "this" {
   name        = var.name
   description = var.description
 
@@ -14,7 +14,7 @@ resource "yandex_mdb_redis_cluster" "this" {
   auth_sentinel          = var.auth_sentinel
   disk_encryption_key_id = var.disk_encryption_key_id
 
-  config {
+  config = {
     password = var.password
 
     version   = var.redis_version
@@ -42,31 +42,27 @@ resource "yandex_mdb_redis_cluster" "this" {
     io_threads_allowed                  = var.io_threads_allowed
     zset_max_listpack_entries           = var.zset_max_listpack_entries
 
-    dynamic "backup_window_start" {
-      for_each = var.backup_window_start != null ? [var.backup_window_start] : []
-      content {
-        hours   = backup_window_start.value.hours
-        minutes = lookup(backup_window_start.value, "minutes", null)
-      }
+    backup_window_start = var.backup_window_start == null ? null : {
+      hours   = var.backup_window_start.hours
+      minutes = coalesce(var.backup_window_start.minutes, 0)
     }
   }
 
-  resources {
+  resources = {
     resource_preset_id = var.resource_preset_id
     disk_size          = var.disk_size
     disk_type_id       = var.disk_type_id
   }
 
-  dynamic "host" {
-    for_each = var.hosts
-    content {
-      zone      = host.value.zone
-      subnet_id = host.value.subnet_id
+  hosts = {
+    for host_key, host in var.hosts : host_key => {
+      zone      = lookup(host, "zone", var.zone)
+      subnet_id = host.subnet_id
 
-      shard_name = var.sharded ? lookup(host.value, "shard_name", "shard-${host.key}") : null
+      shard_name = var.sharded ? lookup(host, "shard_name", "shard-${host_key}") : null
 
-      replica_priority = var.sharded ? null : lookup(host.value, "replica_priority", var.replica_priority)
-      assign_public_ip = var.tls_enabled ? lookup(host.value, "assign_public_ip", var.assign_public_ip) : false
+      replica_priority = var.sharded ? null : lookup(host, "replica_priority", var.replica_priority)
+      assign_public_ip = var.tls_enabled ? lookup(host, "assign_public_ip", var.assign_public_ip) : false
     }
   }
 
@@ -74,38 +70,20 @@ resource "yandex_mdb_redis_cluster" "this" {
 
   labels = var.labels
 
-  dynamic "access" {
-    for_each = var.access != null ? [var.access] : []
-    content {
-      data_lens = lookup(access.value, "data_lens", null)
-      web_sql   = lookup(access.value, "web_sql", null)
-    }
-  }
+  access = var.access
 
-  dynamic "disk_size_autoscaling" {
-    for_each = var.disk_size_autoscaling != null ? [var.disk_size_autoscaling] : []
-    content {
-      disk_size_limit           = disk_size_autoscaling.value.disk_size_limit
-      planned_usage_threshold   = lookup(disk_size_autoscaling.value, "planned_usage_threshold", null)
-      emergency_usage_threshold = lookup(disk_size_autoscaling.value, "emergency_usage_threshold", null)
-    }
-  }
+  disk_size_autoscaling = var.disk_size_autoscaling
 
-  maintenance_window {
+  maintenance_window = {
     type = var.type
 
     hour = var.type == "ANYTIME" ? null : var.hour
     day  = var.type == "ANYTIME" ? null : var.day
   }
 
-  dynamic "timeouts" {
-    for_each = var.timeouts != null ? [var.timeouts] : []
-    content {
-      create = timeouts.value.create
-      update = timeouts.value.update
-      delete = timeouts.value.delete
-    }
-  }
+  modules = var.modules
+
+  timeouts = var.timeouts
 }
 
 moved {
@@ -128,7 +106,7 @@ locals {
 resource "yandex_mdb_redis_user" "this" {
   count = var.user_name != null ? 1 : 0
 
-  cluster_id = yandex_mdb_redis_cluster.this.id
+  cluster_id = yandex_mdb_redis_cluster_v2.this.cluster_id
   name       = var.user_name
   passwords  = [local.user_password]
   permissions = {

--- a/main.tf
+++ b/main.tf
@@ -56,7 +56,7 @@ resource "yandex_mdb_redis_cluster_v2" "this" {
 
   hosts = {
     for host_key, host in var.hosts : host_key => {
-      zone      = lookup(host, "zone", var.zone)
+      zone      = lookup(host, "zone", try(var.zone, null))
       subnet_id = host.subnet_id
 
       shard_name = var.sharded ? lookup(host, "shard_name", "shard-${host_key}") : null

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,97 +1,102 @@
 output "fqdn" {
   description = "FQDN for the Redis cluster"
-  value       = "c-${yandex_mdb_redis_cluster.this.id}.rw.mdb.yandexcloud.net"
+  value       = "c-${yandex_mdb_redis_cluster_v2.this.cluster_id}.rw.mdb.yandexcloud.net"
 }
 
 output "id" {
   description = "ID of the Redis cluster"
-  value       = yandex_mdb_redis_cluster.this.id
+  value       = yandex_mdb_redis_cluster_v2.this.cluster_id
 }
 
 output "name" {
   description = "Name of the Redis cluster"
-  value       = yandex_mdb_redis_cluster.this.name
+  value       = yandex_mdb_redis_cluster_v2.this.name
 }
 
 output "environment" {
   description = "Deployment environment of the Redis cluster"
-  value       = yandex_mdb_redis_cluster.this.environment
+  value       = yandex_mdb_redis_cluster_v2.this.environment
 }
 
 output "network_id" {
   description = "ID of the network to which the Redis cluster belongs"
-  value       = yandex_mdb_redis_cluster.this.network_id
+  value       = yandex_mdb_redis_cluster_v2.this.network_id
 }
 
 output "description" {
   description = "Description of the Redis cluster"
-  value       = yandex_mdb_redis_cluster.this.description
+  value       = yandex_mdb_redis_cluster_v2.this.description
 }
 
 output "folder_id" {
   description = "ID of the folder that the resource belongs to"
-  value       = yandex_mdb_redis_cluster.this.folder_id
+  value       = yandex_mdb_redis_cluster_v2.this.folder_id
 }
 
 output "labels" {
   description = "A set of key/value label pairs to assign to the Redis cluster"
-  value       = yandex_mdb_redis_cluster.this.labels
+  value       = yandex_mdb_redis_cluster_v2.this.labels
 }
 
 output "sharded" {
   description = "Redis Cluster mode enabled/disabled"
-  value       = yandex_mdb_redis_cluster.this.sharded
+  value       = yandex_mdb_redis_cluster_v2.this.sharded
 }
 
 output "tls_enabled" {
   description = "TLS support mode enabled/disabled"
-  value       = yandex_mdb_redis_cluster.this.tls_enabled
+  value       = yandex_mdb_redis_cluster_v2.this.tls_enabled
 }
 
 output "persistence_mode" {
   description = "Persistence mode of the Redis cluster"
-  value       = yandex_mdb_redis_cluster.this.persistence_mode
+  value       = yandex_mdb_redis_cluster_v2.this.persistence_mode
 }
 
 output "security_group_ids" {
   description = "A set of ids of security groups assigned to hosts of the cluster"
-  value       = yandex_mdb_redis_cluster.this.security_group_ids
+  value       = yandex_mdb_redis_cluster_v2.this.security_group_ids
 }
 
 output "deletion_protection" {
   description = "Inhibits deletion of the cluster"
-  value       = yandex_mdb_redis_cluster.this.deletion_protection
+  value       = yandex_mdb_redis_cluster_v2.this.deletion_protection
 }
 
 output "config" {
   description = "Configuration of the Redis cluster"
-  value       = yandex_mdb_redis_cluster.this.config
+  value       = yandex_mdb_redis_cluster_v2.this.config
   sensitive   = true
 }
 
 output "resources" {
   description = "Resources allocated to hosts of the Redis cluster"
-  value       = yandex_mdb_redis_cluster.this.resources
+  value       = yandex_mdb_redis_cluster_v2.this.resources
 }
 
 output "hosts" {
   description = "A list of hosts in the Redis cluster"
-  value       = yandex_mdb_redis_cluster.this.host
+  value       = yandex_mdb_redis_cluster_v2.this.hosts
 }
 
 output "maintenance_window" {
   description = "Maintenance policy of the Redis cluster"
-  value       = yandex_mdb_redis_cluster.this.maintenance_window
+  value       = yandex_mdb_redis_cluster_v2.this.maintenance_window
 }
 
 output "health" {
-  description = "Aggregated health of the cluster"
-  value       = yandex_mdb_redis_cluster.this.health
+  description = "Aggregated health of the cluster. Not exposed by yandex_mdb_redis_cluster_v2."
+  value       = null
 }
 
 output "created_at" {
   description = "Creation timestamp of the cluster"
-  value       = yandex_mdb_redis_cluster.this.created_at
+  value       = yandex_mdb_redis_cluster_v2.this.created_at
+}
+
+output "modules" {
+  description = "Valkey modules configuration"
+  value       = yandex_mdb_redis_cluster_v2.this.modules
 }
 
 output "user_password" {

--- a/variables.tf
+++ b/variables.tf
@@ -197,6 +197,17 @@ variable "assign_public_ip" {
   default     = false
 }
 
+variable "zone" {
+  description = "The availability zone where Redis hosts will be created when a host-specific zone is not provided. See https://cloud.yandex.com/en/docs/overview/concepts/geo-scope"
+  type        = string
+  default     = "ru-central1-a"
+
+  validation {
+    condition     = contains(["ru-central1-a", "ru-central1-b", "ru-central1-c", "ru-central1-d"], var.zone)
+    error_message = "Zone must be one of `ru-central1-a`, `ru-central1-b`, `ru-central1-c` or `ru-central1-d`."
+  }
+}
+
 variable "type" {
   description = "Type of maintenance window. Can be either ANYTIME or WEEKLY. A day and hour of window need to be specified with weekly window"
   type        = string
@@ -395,6 +406,24 @@ variable "access" {
   type = object({
     data_lens = optional(bool)
     web_sql   = optional(bool)
+  })
+  default = null
+}
+
+variable "modules" {
+  description = "Valkey modules configuration"
+  type = object({
+    valkey_search = optional(object({
+      enabled        = optional(bool)
+      reader_threads = optional(number)
+      writer_threads = optional(number)
+    }))
+    valkey_json = optional(object({
+      enabled = optional(bool)
+    }))
+    valkey_bloom = optional(object({
+      enabled = optional(bool)
+    }))
   })
   default = null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -198,13 +198,16 @@ variable "assign_public_ip" {
 }
 
 variable "zone" {
-  description = "The availability zone where Redis hosts will be created when a host-specific zone is not provided. See https://cloud.yandex.com/en/docs/overview/concepts/geo-scope"
+  description = <<-EOT
+    The availability zone where Redis hosts will be created when a host-specific zone is not provided.
+    See https://cloud.yandex.com/en/docs/overview/concepts/geo-scope
+    Example values: ru-central1-a, ru-central1-b, ru-central1-d, ru-central1-e, kz1-a.
+  EOT
   type        = string
-  default     = "ru-central1-a"
 
   validation {
-    condition     = contains(["ru-central1-a", "ru-central1-b", "ru-central1-c", "ru-central1-d"], var.zone)
-    error_message = "Zone must be one of `ru-central1-a`, `ru-central1-b`, `ru-central1-c` or `ru-central1-d`."
+    condition     = can(regex("^[a-z]{2}(-[a-z0-9]+)*-([a-z])$", var.zone))
+    error_message = "Zone must be a valid Yandex Cloud availability zone (e.g. ru-central1-a, ru-central1-e, kz1-a)."
   }
 }
 

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     yandex = {
       source  = "yandex-cloud/yandex"
-      version = ">= 0.47.0"
+      version = ">= 0.183.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/wrappers/main.tf
+++ b/wrappers/main.tf
@@ -29,7 +29,7 @@ module "wrapper" {
   disk_type_id                      = try(each.value.disk_type_id, var.defaults.disk_type_id, "network-ssd")
   replica_priority                  = try(each.value.replica_priority, var.defaults.replica_priority, null)
   assign_public_ip                  = try(each.value.assign_public_ip, var.defaults.assign_public_ip, false)
-  zone                              = try(each.value.zone, var.defaults.zone, "ru-central1-a")
+  zone                              = try(each.value.zone, var.defaults.zone)
   type                              = try(each.value.type, var.defaults.type, "ANYTIME")
   hour                              = try(each.value.hour, var.defaults.hour, 0)
   day                               = try(each.value.day, var.defaults.day, "MON")

--- a/wrappers/main.tf
+++ b/wrappers/main.tf
@@ -29,6 +29,7 @@ module "wrapper" {
   disk_type_id                      = try(each.value.disk_type_id, var.defaults.disk_type_id, "network-ssd")
   replica_priority                  = try(each.value.replica_priority, var.defaults.replica_priority, null)
   assign_public_ip                  = try(each.value.assign_public_ip, var.defaults.assign_public_ip, false)
+  zone                              = try(each.value.zone, var.defaults.zone, "ru-central1-a")
   type                              = try(each.value.type, var.defaults.type, "ANYTIME")
   hour                              = try(each.value.hour, var.defaults.hour, 0)
   day                               = try(each.value.day, var.defaults.day, "MON")
@@ -41,4 +42,5 @@ module "wrapper" {
   disk_encryption_key_id            = try(each.value.disk_encryption_key_id, var.defaults.disk_encryption_key_id, null)
   disk_size_autoscaling             = try(each.value.disk_size_autoscaling, var.defaults.disk_size_autoscaling, null)
   access                            = try(each.value.access, var.defaults.access, null)
+  modules                           = try(each.value.modules, var.defaults.modules, null)
 }


### PR DESCRIPTION
### Summary
    
Migrate Redis cluster resource from yandex_mdb_redis_cluster to yandex_mdb_redis_cluster_v2 and add support for Valkey modules (valkey_search, valkey_json, valkey_bloom).

Main changes:
- switch resource type to yandex_mdb_redis_cluster_v2;
- add modules input variable for Valkey modules;
- pass modules through the wrapper module;
- bump Yandex provider requirement to >= 0.183.0;
- update all outputs to use _v2 attributes (cluster_id, modules, etc.);
- keep zone input for backward compatibility.

### Migration note

This change cannot use Terraform moved block for existing clusters — the Yandex provider (>= 0.183.0) does not support cross-type state move from yandex_mdb_redis_cluster to yandex_mdb_redis_cluster_v2 (fails with Unable to Move Resource State).

**Existing users must migrate state manually:**

```bash
terraform state pull > state-before-redis-v2-migration.json

terraform state rm '<old resource address>'
terraform import '<new yandex_mdb_redis_cluster_v2 resource address>' '<cluster_id>'

terraform plan
```

The cluster itself is not recreated by these commands, only Terraform state is mutated.

### Compatibility

- Provider minimum version: >= 0.183.0
- health output is kept for compatibility but always returns null (not exposed by _v2)
- Existing v1.x configurations need manual state migration before applying

### Validation

- terraform fmt -recursive: passed
- terraform validate (provider >= 0.183.0): passed
- terraform validate (pinned = 0.183.0): passed
- pre-commit run -a: passed